### PR TITLE
gulp-data を使用し、テンプレートの相対パスを変数として pug に渡すサンプル

### DIFF
--- a/develop/about.pug
+++ b/develop/about.pug
@@ -12,3 +12,4 @@ append variables
   - var pageOgpType= "article";
 
 block content
+  p #{relativePath}

--- a/develop/index.pug
+++ b/develop/index.pug
@@ -12,3 +12,4 @@ append variables
   - var pageOgpType= "website";
 
 block content
+  p #{relativePath}

--- a/develop/page/index.pug
+++ b/develop/page/index.pug
@@ -12,3 +12,4 @@ append variables
   - var pageOgpType= "article";
 
 block content
+  p #{relativePath}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,8 @@ var sourcemaps = require('gulp-sourcemaps');
 var plumber = require('gulp-plumber');
 var notify = require("gulp-notify");
 var rimraf = require('rimraf');
+var data = require('gulp-data');
+var path = require('path');
 
 /**
  * 開発用ディレクトリ
@@ -99,6 +101,12 @@ gulp.task('pug', function() {
   }
   return gulp.src(develop.pug)
   .pipe(plumber({errorHandler: notify.onError("Error: <%= error.message %>")}))
+  .pipe(data(function(file) {
+    // 相対パスを求めて locals に格納
+    // todo: 拡張子の変更が必要?
+    locals.relativePath = path.relative(file.base, file.path);
+    return locals;
+  }))
   .pipe(pug({
     // JSONファイルをPugに渡します。
     locals: locals,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-consolidate": "^0.2.0",
     "gulp-csscomb": "^3.0.7",
+    "gulp-data": "^1.2.1",
     "gulp-iconfont": "^8.0.1",
     "gulp-imagemin": "^3.0.3",
     "gulp-notify": "^2.2.0",


### PR DESCRIPTION
gulp-data と path を使用して、
テンプレートの相対パスを 変数 locals に格納するサンプルです

(gulp-jade と gulp-data の組み合わせについては、gulp-jade のオフィシャルにも記述あり)
https://www.npmjs.com/package/gulp-jade

いまはテンプレートファイル名をそのまま相対パス化しているだけなので、
拡張子 .pug を .html に変更する必要など、あるかもしれません。

ご確認ください〜
